### PR TITLE
Dynamic Scheduling

### DIFF
--- a/src/Recorders/OutdatedRecorder.php
+++ b/src/Recorders/OutdatedRecorder.php
@@ -34,6 +34,11 @@ class OutdatedRecorder
     {
         $class = self::class;
         $expression = $this->config->get(sprintf('pulse.recorders.%s.cron', $class), '0 0 * * *');
+
+        if (! CronExpression::isValidExpression($expression)) {
+            throw new RuntimeException('Invalid cron expression: '.$expression);
+        }
+
         $cronExpression = CronExpression::factory($expression);
 
         if (! $cronExpression->isDue($event->time)) {

--- a/src/Recorders/OutdatedRecorder.php
+++ b/src/Recorders/OutdatedRecorder.php
@@ -32,7 +32,11 @@ class OutdatedRecorder
 
     public function record(SharedBeat $event): void
     {
-        if ($event->time !== $event->time->startOfDay()) {
+        $class = self::class;
+        $expression = $this->config->get(sprintf('pulse.recorders.%s.cron', $class), '0 0 * * *');
+        $cronExpression = CronExpression::factory($expression);
+
+        if (! $cronExpression->isDue($event->time)) {
             return;
         }
 


### PR DESCRIPTION
**Problem**

Currently, the command only runs at midnight. This is not a problem if Pulse runs at exactly midnight. However, at the moment I cannot influence this value, for example setting it to dawn or night. When installing the package, I have to wait a day for the first result. Although this is not a problem since I can run the command myself, it would be more convenient to customize the package.

**Solution**

I replaced the fixed time check with a cron-based check that allows any scheduling using the cron syntax.

The default cron expression `0 0 * * *` means it runs every day at midnight (so the current logic remains the same).

However, in the `config/pulse.php` file, when declaring the Recorder, a parameter called cron can be specified, which overrides this value.

```diff
return [
    // ...
    
    'recorders' => [
        \AaronFrancis\Pulse\Outdated\Recorders\OutdatedRecorder::class => [
+           'cron' => '0 15 * * *' // schedule: every day at 3 PM
        ],
    ]
]
```